### PR TITLE
changed regex placeholder text

### DIFF
--- a/R/regex_gadget.R
+++ b/R/regex_gadget.R
@@ -54,7 +54,7 @@ regex_gadget <- function(
               fillRow(
                 flex = c(6, 1),
                 textInputCode('pattern', 'RegEx', width = "100%",
-                              placeholder = "Standard RegEx, e.g. \\w+_\\d{2,4}\\s+"),
+                              placeholder = "Standard RegEx WITH SINGLE SLASH FOR ESCAPE, e.g. \\w+_\\d{2,4}\\s+"),
                 tags$div(style = "margin-top: 23px; margin-left:6px;",
                          actionButton("library_show", "Library", class = "btn-success"))
               ),
@@ -283,7 +283,7 @@ regex_gadget <- function(
       is_empty <- input$pattern == ""
       if (is_empty) updateTextInput(
         session, "pattern",
-        placeholder = "Standard RegEx, e.g. \\w+_\\d{2,4}\\s+")
+        placeholder = "Standard RegEx WITH SINGLE SLASH FOR ESCAPE, e.g. \\w+_\\d{2,4}\\s+")
     })
 
     # ---- Server - Tab - Output ----


### PR DESCRIPTION
Hi Garrick. Just a small suggestion and of course feel free to blow off (or modify), but I would find it helpful to have a _specific warning_ in the regex placeholder text that I need a single backslash as an escape character instead of a double slash. I know it's in the help file, but even those of us who might have read the help file when first installing the add-in could forget about needing a single backslash a few months later. "Standard RegEx" and the example probably _should have_ been enough to jog my memory but wasn't.  Wish I could have coded an additional feature adding a checkbox for "use double slash" or "use single slash" but couldn't quite figure out how to do that after reading the code, sorry!